### PR TITLE
Migrate jda-ktx to the latest version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file build.gradle.kts is part of PolyhedralBot
- * Last modified on 30-12-2021 08:50 p.m.
+ * Last modified on 31-12-2021 01:35 p.m.
  *
  * MIT License
  *
@@ -143,7 +143,7 @@ dependencies {
     // Discord webhooks
     implementation("club.minnced:discord-webhooks:$DISCORD_WEBHOOKS_VERSION")
     // JDA Kotlin extensions
-    implementation("com.github.solonovamax:jda-ktx:$JDA_KTX_VERSION")
+    implementation("com.github.minndevelopment:jda-ktx:$JDA_KTX_VERSION")
     // JDA utilities
     implementation("com.jagrosh:jda-utilities-commons:$JDA_UTILITIES_VERSION")
     implementation("com.jagrosh:jda-utilities-menu:$JDA_UTILITIES_VERSION")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
 #
 # The file gradle.properties is part of PolyhedralBot
-# Last modified on 30-12-2021 08:36 p.m.
+# Last modified on 31-12-2021 01:19 p.m.
 #
 # MIT License
 #
@@ -49,7 +49,7 @@ KOTLINX_UUID_VERSION=0.0.12
 JETBRAINS_ANNOTATIONS_VERSION=22.0.0
 JDA_VERSION=4.3.0_313
 DISCORD_WEBHOOKS_VERSION=0.7.4
-JDA_KTX_VERSION=0.5.1-polybot
+JDA_KTX_VERSION=0.7.0
 JDA_UTILITIES_VERSION=3.0.5
 CLOUD_VERSION=1.6.1
 KRYO_VERSION=5.2.1

--- a/src/main/kotlin/ca/solostudios/polybot/Launcher.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/Launcher.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file Launcher.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:58 p.m.
+ * Last modified on 31-12-2021 01:38 p.m.
  *
  * MIT License
  *
@@ -31,6 +31,8 @@
 package ca.solostudios.polybot
 
 import ca.solostudios.polybot.config.PolyConfig
+import ca.solostudios.polybot.util.jda.DefaultJDABuilder
+import ca.solostudios.polybot.util.jda.or
 import ca.solostudios.polybot.util.onJvmShutdown
 import ca.solostudios.polybot.util.removeJvmShutdownThread
 import com.fasterxml.jackson.core.JsonGenerator
@@ -40,8 +42,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.jasonclawson.jackson.dataformat.hocon.HoconFactory
-import dev.minn.jda.ktx.DefaultJDABuilder
-import dev.minn.jda.ktx.or
 import java.io.File
 import java.nio.file.Path
 import java.sql.Connection

--- a/src/main/kotlin/ca/solostudios/polybot/PolyBot.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/PolyBot.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyBot.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 05:28 p.m.
+ * Last modified on 31-12-2021 01:38 p.m.
  *
  * MIT License
  *
@@ -57,13 +57,14 @@ import ca.solostudios.polybot.listener.LoggingListener
 import ca.solostudios.polybot.listener.PolyBotListener
 import ca.solostudios.polybot.search.SearchManager
 import ca.solostudios.polybot.util.AnnotationParser
-import ca.solostudios.polybot.util.BackedReference
 import ca.solostudios.polybot.util.ScheduledThreadPool
 import ca.solostudios.polybot.util.currentThread
+import ca.solostudios.polybot.util.datastructures.BackedReference
 import ca.solostudios.polybot.util.fixedRate
-import ca.solostudios.polybot.util.onlineStatus
+import ca.solostudios.polybot.util.jda.InlineJDABuilder
+import ca.solostudios.polybot.util.jda.onlineStatus
+import ca.solostudios.polybot.util.jda.poly
 import ca.solostudios.polybot.util.parseCommands
-import ca.solostudios.polybot.util.poly
 import ca.solostudios.polybot.util.processors
 import ca.solostudios.polybot.util.runtime
 import ca.solostudios.polybot.util.subTypesOf
@@ -71,7 +72,6 @@ import cloud.commandframework.annotations.AnnotationParser
 import cloud.commandframework.annotations.CommandDescription
 import cloud.commandframework.kotlin.coroutines.annotations.installCoroutineSupport
 import cloud.commandframework.meta.SimpleCommandMeta
-import dev.minn.jda.ktx.InlineJDABuilder
 import it.unimi.dsi.util.XoShiRo256PlusPlusRandom
 import java.util.EnumSet
 import java.util.concurrent.ScheduledExecutorService

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/CloudInjectionService.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/CloudInjectionService.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file CloudInjectionService.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:28 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -42,7 +42,7 @@ import ca.solostudios.polybot.entities.PolyUser
 import ca.solostudios.polybot.util.component1
 import ca.solostudios.polybot.util.component2
 import ca.solostudios.polybot.util.component3
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.annotations.AnnotationAccessor
 import cloud.commandframework.annotations.injection.InjectionService
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/event/GuildMessageEvent.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/event/GuildMessageEvent.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file GuildMessageEvent.kt is part of PolyhedralBot
- * Last modified on 22-12-2021 11:41 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@ package ca.solostudios.polybot.cloud.event
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyMember
 import ca.solostudios.polybot.entities.PolyTextChannel
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 data class GuildMessageEvent(

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/event/MessageEvent.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/event/MessageEvent.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file MessageEvent.kt is part of PolyhedralBot
- * Last modified on 22-12-2021 11:41 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -32,7 +32,7 @@ import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyMessage
 import ca.solostudios.polybot.entities.PolyMessageChannel
 import ca.solostudios.polybot.entities.PolyUser
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 open class MessageEvent(

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/MemberParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/MemberParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file MemberParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyMember
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/MessageChannelParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/MessageChannelParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file MessageChannelParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyMessageChannel
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/RoleParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/RoleParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file RoleParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyRole
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/TagParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/TagParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file TagParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.data.PolyTagData
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/TextChannelParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/TextChannelParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file TextChannelParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyTextChannel
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/cloud/parser/UserParser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/cloud/parser/UserParser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file UserParser.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:37 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.cloud.parser
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyUser
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.arguments.parser.ArgumentParseResult
 import cloud.commandframework.arguments.parser.ArgumentParser
 import cloud.commandframework.context.CommandContext

--- a/src/main/kotlin/ca/solostudios/polybot/commands/HelpCommands.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/commands/HelpCommands.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file HelpCommands.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:28 p.m.
+ * Last modified on 31-12-2021 01:26 p.m.
  *
  * MIT License
  *
@@ -44,7 +44,7 @@ import ca.solostudios.polybot.cloud.commands.annotations.SourceMessage
 import ca.solostudios.polybot.entities.PolyMember
 import ca.solostudios.polybot.entities.PolyMessage
 import ca.solostudios.polybot.entities.PolyUser
-import ca.solostudios.polybot.util.PaginationMenu
+import ca.solostudios.polybot.util.jda.PaginationMenu
 import cloud.commandframework.annotations.Argument
 import cloud.commandframework.annotations.CommandDescription
 import cloud.commandframework.annotations.CommandMethod

--- a/src/main/kotlin/ca/solostudios/polybot/commands/LuceneCommands.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/commands/LuceneCommands.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file LuceneCommands.kt is part of PolyhedralBot
- * Last modified on 23-12-2021 03:28 p.m.
+ * Last modified on 31-12-2021 01:38 p.m.
  *
  * MIT License
  *
@@ -40,8 +40,8 @@ import ca.solostudios.polybot.cloud.commands.annotations.SourceMessage
 import ca.solostudios.polybot.entities.PolyMessage
 import ca.solostudios.polybot.entities.PolyUser
 import ca.solostudios.polybot.util.MarkdownHeaderVisitor
-import ca.solostudios.polybot.util.PaginationMenu
 import ca.solostudios.polybot.util.get
+import ca.solostudios.polybot.util.jda.PaginationMenu
 import cloud.commandframework.annotations.Argument
 import cloud.commandframework.annotations.CommandDescription
 import cloud.commandframework.annotations.CommandMethod

--- a/src/main/kotlin/ca/solostudios/polybot/commands/ModerationCommands.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/commands/ModerationCommands.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file ModerationCommands.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:19 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -44,7 +44,7 @@ import ca.solostudios.polybot.entities.PolyMember
 import ca.solostudios.polybot.entities.PolyMessage
 import ca.solostudios.polybot.entities.PolyTextChannel
 import ca.solostudios.polybot.event.moderation.PolyClearEvent
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import cloud.commandframework.annotations.Argument
 import cloud.commandframework.annotations.CommandDescription
 import cloud.commandframework.annotations.CommandMethod

--- a/src/main/kotlin/ca/solostudios/polybot/commands/TagCommands.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/commands/TagCommands.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file TagCommands.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:26 p.m.
+ * Last modified on 31-12-2021 01:31 p.m.
  *
  * MIT License
  *
@@ -42,7 +42,7 @@ import ca.solostudios.polybot.entities.PolyGuild
 import ca.solostudios.polybot.entities.PolyMessage
 import ca.solostudios.polybot.entities.data.Tag
 import ca.solostudios.polybot.util.chunkedBy
-import ca.solostudios.polybot.util.toDiscordTimestamp
+import ca.solostudios.polybot.util.jda.toDiscordTimestamp
 import cloud.commandframework.annotations.Argument
 import cloud.commandframework.annotations.CommandDescription
 import cloud.commandframework.annotations.CommandMethod

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyEmote.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyEmote.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyEmote.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:35 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import net.dv8tion.jda.api.entities.Emote
 
 class PolyEmote(val bot: PolyBot, val jdaEmote: Emote) {

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyGuild.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyGuild.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyGuild.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:35 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -32,7 +32,7 @@ package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.data.PolyTagData
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import java.util.Locale
 import net.dv8tion.jda.api.entities.Guild
 

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyMember.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyMember.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyMember.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:58 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import dev.minn.jda.ktx.await
 import java.awt.Color
 import java.time.LocalDateTime

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyMessage.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyMessage.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyMessage.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:35 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import dev.minn.jda.ktx.await
 import java.time.OffsetDateTime
 import java.util.EnumSet

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyMessageChannel.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyMessageChannel.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyMessageChannel.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:35 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import dev.minn.jda.ktx.await
 import java.util.EnumSet
 import net.dv8tion.jda.api.entities.Message

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyRole.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyRole.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyRole.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:31 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import java.awt.Color
 import net.dv8tion.jda.api.entities.Role
 

--- a/src/main/kotlin/ca/solostudios/polybot/entities/PolyUser.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/entities/PolyUser.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PolyUser.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:35 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@
 package ca.solostudios.polybot.entities
 
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import dev.minn.jda.ktx.await
 import net.dv8tion.jda.api.entities.User
 

--- a/src/main/kotlin/ca/solostudios/polybot/listener/AutoQuoteListener.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/listener/AutoQuoteListener.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file AutoQuoteListener.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 08:38 p.m.
+ * Last modified on 31-12-2021 01:32 p.m.
  *
  * MIT License
  *
@@ -30,7 +30,7 @@ package ca.solostudios.polybot.listener
 
 import ca.solostudios.polybot.Constants
 import ca.solostudios.polybot.PolyBot
-import ca.solostudios.polybot.util.WebhookMessage
+import ca.solostudios.polybot.util.jda.WebhookMessage
 import club.minnced.discord.webhook.WebhookClientBuilder
 import club.minnced.discord.webhook.external.JDAWebhookClient
 import club.minnced.discord.webhook.send.AllowedMentions

--- a/src/main/kotlin/ca/solostudios/polybot/listener/LoggingListener.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/listener/LoggingListener.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file LoggingListener.kt is part of PolyhedralBot
- * Last modified on 20-10-2021 12:50 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -31,7 +31,7 @@ package ca.solostudios.polybot.listener
 import ca.solostudios.polybot.Constants
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.util.idFooter
-import ca.solostudios.polybot.util.poly
+import ca.solostudios.polybot.util.jda.poly
 import dev.minn.jda.ktx.Embed
 import dev.minn.jda.ktx.InlineEmbed
 import dev.minn.jda.ktx.await

--- a/src/main/kotlin/ca/solostudios/polybot/util/datastructures/BackedReference.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/datastructures/BackedReference.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file BackedReference.kt is part of PolyhedralBot
- * Last modified on 09-10-2021 10:58 p.m.
+ * Last modified on 31-12-2021 01:38 p.m.
  *
  * MIT License
  *
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-package ca.solostudios.polybot.util
+package ca.solostudios.polybot.util.datastructures
 
 import java.lang.ref.WeakReference
 import kotlin.reflect.KProperty

--- a/src/main/kotlin/ca/solostudios/polybot/util/datastructures/DelegatingCollection.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/datastructures/DelegatingCollection.kt
@@ -1,0 +1,83 @@
+/*
+ * PolyhedralBot - A Discord bot for the Polyhedral Development discord server
+ * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
+ *
+ * The file DelegatingCollection.kt is part of PolyhedralBot
+ * Last modified on 31-12-2021 01:38 p.m.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * POLYHEDRALBOT IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ca.solostudios.polybot.util.datastructures
+
+import java.util.function.Predicate
+
+internal class DelegatingCollection<T>(
+        private val delegate: MutableCollection<T> = mutableListOf(),
+        private val adder: (toAdd: T) -> Unit,
+        private val remover: (toRemove: T) -> Unit,
+                                      ) : MutableCollection<T> by delegate {
+    override fun add(element: T): Boolean {
+        adder(element)
+        return delegate.add(element)
+    }
+    
+    override fun addAll(elements: Collection<T>): Boolean {
+        elements.forEach(adder)
+        return delegate.addAll(elements)
+    }
+    
+    override fun clear() {
+        delegate.forEach(remover)
+        delegate.clear()
+    }
+    
+    override fun remove(element: T): Boolean {
+        remover(element)
+        return delegate.remove(element)
+    }
+    
+    override fun removeAll(elements: Collection<T>): Boolean {
+        elements.forEach(remover)
+        return delegate.removeAll(elements)
+    }
+    
+    override fun removeIf(filter: Predicate<in T>): Boolean {
+        @Suppress("LABEL_NAME_CLASH")
+        return delegate.removeIf { element ->
+            if (filter.test(element)) {
+                remover(element)
+                return@removeIf true
+            }
+            return@removeIf false
+        }
+    }
+    
+    override fun retainAll(elements: Collection<T>): Boolean {
+        return delegate.removeIf { element ->
+            if (!elements.contains(element)) {
+                remover(element)
+                return@removeIf true
+            }
+            return@removeIf false
+        }
+    }
+}

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineJDABuilder.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineJDABuilder.kt
@@ -1,0 +1,353 @@
+/*
+ * PolyhedralBot - A Discord bot for the Polyhedral Development discord server
+ * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
+ *
+ * The file InlineJDABuilder.kt is part of PolyhedralBot
+ * Last modified on 31-12-2021 01:32 p.m.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * POLYHEDRALBOT IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ca.solostudios.polybot.util.jda
+
+import ca.solostudios.polybot.util.datastructures.DelegatingCollection
+import com.neovisionaries.ws.client.WebSocketFactory
+import dev.minn.jda.ktx.injectKTX
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
+import net.dv8tion.jda.api.GatewayEncoding
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.JDABuilder
+import net.dv8tion.jda.api.OnlineStatus
+import net.dv8tion.jda.api.audio.factory.IAudioSendFactory
+import net.dv8tion.jda.api.audio.factory.IAudioSendSystem
+import net.dv8tion.jda.api.audio.factory.IPacketProvider
+import net.dv8tion.jda.api.entities.Activity
+import net.dv8tion.jda.api.hooks.IEventManager
+import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor
+import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder
+import net.dv8tion.jda.api.utils.ChunkingFilter
+import net.dv8tion.jda.api.utils.Compression
+import net.dv8tion.jda.api.utils.MemberCachePolicy
+import net.dv8tion.jda.api.utils.SessionController
+import net.dv8tion.jda.api.utils.cache.CacheFlag
+import okhttp3.OkHttpClient
+
+/**
+ * Makes construction of a [JDA] much more idiomatic and cleaner to do in kotlin.
+ *
+ * @property builder The delegate [JDABuilder].
+ * @constructor Create an inline shard manager builder to make construction of the [JDA] more idiomatic in kotlin.
+ */
+class InlineJDABuilder(val builder: JDABuilder) {
+    var gatewayEncoding: GatewayEncoding? = null
+        set(value) {
+            if (value != null) {
+                builder.setGatewayEncoding(value)
+            }
+            field = value
+        }
+    
+    var rawEvents: Boolean = false
+        set(value) {
+            builder.setRawEventsEnabled(value)
+            field = value
+        }
+    
+    var relativeRateLimit: Boolean = true
+        set(value) {
+            builder.setRelativeRateLimit(value)
+            field = value
+        }
+    
+    var enableCache: Collection<CacheFlag> = emptySet()
+        set(value) {
+            builder.enableCache(value)
+            field = value
+        }
+    
+    var disableCache: Collection<CacheFlag> = emptySet()
+        set(value) {
+            builder.disableCache(value)
+            field = value
+        }
+    
+    var memberCachePolicy: MemberCachePolicy? = null
+        set(value) {
+            builder.setMemberCachePolicy(value)
+            field = value
+        }
+    
+    var contextMap: ConcurrentMap<String, String>? = null
+        set(value) {
+            builder.setContextMap(value)
+            field = value
+        }
+    
+    var context: Boolean = true
+        set(value) {
+            builder.setContextEnabled(value)
+            field = value
+        }
+    
+    var compression: Compression? = null
+        set(value) {
+            if (value != null) {
+                builder.setCompression(value)
+            }
+            field = value
+        }
+    
+    var requestTimeoutRetry: Boolean = true
+        set(value) {
+            builder.setRequestTimeoutRetry(value)
+            field = value
+        }
+    
+    var token: String? = null
+        set(value) {
+            builder.setToken(value)
+            field = value
+        }
+    
+    var httpClientBuilder: OkHttpClient.Builder? = null
+        set(value) {
+            builder.setHttpClientBuilder(value)
+            field = value
+        }
+    
+    var httpClient: OkHttpClient? = null
+        set(value) {
+            builder.setHttpClient(value)
+            field = value
+        }
+    
+    var webSocketFactory: WebSocketFactory? = null
+        set(value) {
+            builder.setWebsocketFactory(value)
+            field = value
+        }
+    
+    var rateLimitPool: ScheduledExecutorService? = null
+        set(value) {
+            builder.setRateLimitPool(value, true)
+            field = value
+        }
+    
+    var gatewayPool: ScheduledExecutorService? = null
+        set(value) {
+            builder.setGatewayPool(value, true)
+            field = value
+        }
+    
+    var callbackPool: ExecutorService? = null
+        set(value) {
+            builder.setCallbackPool(value, true)
+            field = value
+        }
+    
+    var eventPool: ExecutorService? = null
+        set(value) {
+            builder.setEventPool(value, true)
+            field = value
+        }
+    
+    var audioPool: ScheduledExecutorService? = null
+        set(value) {
+            builder.setAudioPool(value, true)
+            field = value
+        }
+    
+    var bulkDeleteSplitting: Boolean = true
+        set(value) {
+            builder.setBulkDeleteSplittingEnabled(value)
+            field = value
+        }
+    
+    var enableShutdownHook: Boolean = true
+        set(value) {
+            builder.setEnableShutdownHook(value)
+            field = value
+        }
+    
+    var autoReconnect: Boolean = true
+        set(value) {
+            builder.setAutoReconnect(value)
+            field = value
+        }
+    
+    var eventManager: IEventManager? = null
+        set(value) {
+            builder.setEventManager(value)
+            field = value
+        }
+    
+    var audioSendFactory: IAudioSendFactory? = null
+        set(value) {
+            builder.setAudioSendFactory(value)
+            field = value
+        }
+    
+    /**
+     * Allows an audio send factory to be set via a lambda.
+     *
+     * eg:
+     * ```kotlin
+     * audioSendFactory {
+     *     DefaultSendSystem(it)
+     * }
+     * ```
+     */
+    fun audioSendFactory(factory: (IPacketProvider) -> IAudioSendSystem) {
+        audioSendFactory = IAudioSendFactory(factory)
+    }
+    
+    var idle: Boolean = false
+        set(value) {
+            builder.setIdle(value)
+            field = value
+        }
+    
+    var activity: Activity? = null
+        set(value) {
+            builder.setActivity(value)
+            field = value
+        }
+    
+    var status: OnlineStatus? = null
+        set(value) {
+            if (value != null) {
+                builder.setStatus(value)
+            }
+            field = value
+        }
+    
+    val eventListeners: MutableCollection<Any> = DelegatingCollection(
+            adder = { item -> builder.addEventListeners(item) },
+            remover = { item -> builder.removeEventListeners(item) },
+                                                                     )
+    
+    var maxReconnectDelay: Int = 900
+        set(value) {
+            builder.setMaxReconnectDelay(value)
+            field = value
+        }
+    
+    fun sharding(shardId: Int, shardTotal: Int) = builder.useSharding(shardId, shardTotal)
+    
+    var sessionController: SessionController? = null
+        set(value) {
+            builder.setSessionController(value)
+            field = value
+        }
+    
+    var voiceDispatchInterceptor: VoiceDispatchInterceptor? = null
+        set(value) {
+            builder.setVoiceDispatchInterceptor(value)
+            field = value
+        }
+    
+    var chunkingFilter: ChunkingFilter? = null
+        set(value) {
+            builder.setChunkingFilter(value)
+            field = value
+        }
+    
+    /**
+     * Sets the [chunking filter][DefaultShardManagerBuilder.setChunkingFilter] for all guilds.
+     *
+     * eg:
+     * ```kotlin
+     * chunkingFilter {
+     *     return (it % 2) == 0L // only chunk guilds with an id % 2 = 0 (why tho)
+     * }
+     * ```
+     *
+     * @param filter The chunking filter
+     */
+    fun chunkingFilter(filter: (Long) -> Boolean) {
+        chunkingFilter = ChunkingFilter(filter)
+    }
+    
+    /**
+     * Sets the [chunking filter][DefaultShardManagerBuilder.setChunkingFilter] for all guilds.
+     *
+     * @param ids The ids to filter for
+     * @param include Whether to include or exclude these guilds for chunking
+     * @see ChunkingFilter.include
+     * @see ChunkingFilter.exclude
+     */
+    fun chunkingFilterByIds(include: Boolean = true, vararg ids: Long) {
+        chunkingFilterByIds(include, ids.asList())
+    }
+    
+    /**
+     * Sets the [chunking filter][DefaultShardManagerBuilder.setChunkingFilter] for all guilds.
+     *
+     * @param ids The ids to filter for
+     * @param include Whether to include or exclude these guilds for chunking
+     * @see ChunkingFilter.include
+     * @see ChunkingFilter.exclude
+     */
+    fun chunkingFilterByIds(include: Boolean = true, ids: Collection<Long>) {
+        chunkingFilter {
+            for (id in ids)
+                return@chunkingFilter include
+            return@chunkingFilter !include
+        }
+    }
+    
+    var enableIntents: Collection<GatewayIntent> = emptySet()
+        set(value) {
+            builder.enableIntents(value)
+            field = value
+        }
+    
+    var disableIntents: Collection<GatewayIntent> = emptySet()
+        set(value) {
+            builder.disableIntents(value)
+            field = value
+        }
+    
+    var largeThreshold: Int = 250
+        set(value) {
+            builder.setLargeThreshold(value)
+            field = value
+        }
+    
+    var maxBufferSize: Int = 2048
+        set(value) {
+            builder.setMaxBufferSize(value)
+            field = value
+        }
+    
+    var injectKtx: Boolean = true
+    
+    fun build(): JDA {
+        if (injectKtx) {
+            builder.injectKTX()
+        }
+        
+        return builder.build()
+    }
+}

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineWebhookBuilder.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineWebhookBuilder.kt
@@ -2,8 +2,8 @@
  * PolyhedralBot - A Discord bot for the Polyhedral Development discord server
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
- * The file webhook.kt is part of PolyhedralBot
- * Last modified on 09-10-2021 10:58 p.m.
+ * The file InlineWebhookBuilder.kt is part of PolyhedralBot
+ * Last modified on 31-12-2021 01:33 p.m.
  *
  * MIT License
  *
@@ -26,35 +26,15 @@
  * SOFTWARE.
  */
 
-@file:Suppress("NOTHING_TO_INLINE", "unused", "FunctionName")
+@file:Suppress("NOTHING_TO_INLINE")
 
-package ca.solostudios.polybot.util
+package ca.solostudios.polybot.util.jda
 
 import club.minnced.discord.webhook.send.AllowedMentions
-import club.minnced.discord.webhook.send.WebhookEmbed
-import club.minnced.discord.webhook.send.WebhookEmbed.EmbedAuthor
-import club.minnced.discord.webhook.send.WebhookEmbed.EmbedFooter
-import club.minnced.discord.webhook.send.WebhookEmbed.EmbedTitle
 import club.minnced.discord.webhook.send.WebhookEmbedBuilder
-import club.minnced.discord.webhook.send.WebhookMessage
 import club.minnced.discord.webhook.send.WebhookMessageBuilder
 import java.io.File
 import java.io.InputStream
-import java.time.OffsetDateTime
-
-inline fun WebhookMessage(builder: InlineWebhookMessage.() -> Unit = {}): WebhookMessage {
-    return WebhookMessageBuilder().run {
-        InlineWebhookMessage(this).builder()
-        build()
-    }
-}
-
-inline fun WebhookMessageBuilder(builder: InlineWebhookMessage.() -> Unit = {}): InlineWebhookMessage {
-    return WebhookMessageBuilder().run {
-        InlineWebhookMessage(this).apply(builder)
-    }
-}
-
 
 class InlineWebhookMessage(val builder: WebhookMessageBuilder) {
     fun build() = builder.build()
@@ -112,56 +92,5 @@ class InlineWebhookMessage(val builder: WebhookMessageBuilder) {
     
     inline fun file(name: String, data: InputStream) {
         builder.addFile(name, data)
-    }
-    
-}
-
-class InlineWebhookEmbed(val builder: WebhookEmbedBuilder) {
-    fun build() = builder.build()
-    
-    var timestamp: OffsetDateTime? = null
-        set(value) {
-            builder.setTimestamp(value)
-            field = value
-        }
-    
-    var color: Int? = null
-        set(value) {
-            builder.setColor(value)
-            field = value
-        }
-    
-    var description: String? = null
-        set(value) {
-            builder.setDescription(value)
-            field = value
-        }
-    
-    var thumbnailUrl: String? = null
-        set(value) {
-            builder.setThumbnailUrl(value)
-            field = value
-        }
-    
-    var imageUrl: String? = null
-        set(value) {
-            builder.setImageUrl(value)
-            field = value
-        }
-    
-    inline fun footer(text: String, icon: String?) {
-        builder.setFooter(EmbedFooter(text, icon))
-    }
-    
-    inline fun title(text: String, url: String?) {
-        builder.setTitle(EmbedTitle(text, url))
-    }
-    
-    inline fun author(name: String, iconUrl: String?, url: String?) {
-        builder.setAuthor(EmbedAuthor(name, iconUrl, url))
-    }
-    
-    inline fun field(name: String, content: String, inline: Boolean = false) {
-        builder.addField(WebhookEmbed.EmbedField(inline, name, content))
     }
 }

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineWebhookEmbed.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/InlineWebhookEmbed.kt
@@ -1,0 +1,85 @@
+/*
+ * PolyhedralBot - A Discord bot for the Polyhedral Development discord server
+ * Copyright (c) 2021 solonovamax <solonovamax@12oclockpoint.com>
+ *
+ * The file InlineWebhookEmbed.kt is part of PolyhedralBot
+ * Last modified on 31-12-2021 01:33 p.m.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * POLYHEDRALBOT IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:Suppress("NOTHING_TO_INLINE")
+
+package ca.solostudios.polybot.util.jda
+
+import club.minnced.discord.webhook.send.WebhookEmbed
+import club.minnced.discord.webhook.send.WebhookEmbedBuilder
+import java.time.OffsetDateTime
+
+class InlineWebhookEmbed(val builder: WebhookEmbedBuilder) {
+    fun build() = builder.build()
+    
+    var timestamp: OffsetDateTime? = null
+        set(value) {
+            builder.setTimestamp(value)
+            field = value
+        }
+    
+    var color: Int? = null
+        set(value) {
+            builder.setColor(value)
+            field = value
+        }
+    
+    var description: String? = null
+        set(value) {
+            builder.setDescription(value)
+            field = value
+        }
+    
+    var thumbnailUrl: String? = null
+        set(value) {
+            builder.setThumbnailUrl(value)
+            field = value
+        }
+    
+    var imageUrl: String? = null
+        set(value) {
+            builder.setImageUrl(value)
+            field = value
+        }
+    
+    inline fun footer(text: String, icon: String?) {
+        builder.setFooter(WebhookEmbed.EmbedFooter(text, icon))
+    }
+    
+    inline fun title(text: String, url: String?) {
+        builder.setTitle(WebhookEmbed.EmbedTitle(text, url))
+    }
+    
+    inline fun author(name: String, iconUrl: String?, url: String?) {
+        builder.setAuthor(WebhookEmbed.EmbedAuthor(name, iconUrl, url))
+    }
+    
+    inline fun field(name: String, content: String, inline: Boolean = false) {
+        builder.addField(WebhookEmbed.EmbedField(inline, name, content))
+    }
+}

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/PaginationMenu.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/PaginationMenu.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file PaginationMenu.kt is part of PolyhedralBot
- * Last modified on 30-12-2021 03:26 p.m.
+ * Last modified on 31-12-2021 01:26 p.m.
  *
  * MIT License
  *
@@ -28,7 +28,7 @@
 
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")
 
-package ca.solostudios.polybot.util
+package ca.solostudios.polybot.util.jda
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter
 import com.jagrosh.jdautilities.menu.Menu

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/builders.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/builders.kt
@@ -1,0 +1,193 @@
+/*
+ * PolyhedralBot - A Discord bot for the Polyhedral Development discord server
+ * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
+ *
+ * The file builders.kt is part of PolyhedralBot
+ * Last modified on 31-12-2021 01:34 p.m.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * POLYHEDRALBOT IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:Suppress("MemberVisibilityCanBePrivate", "unused", "FunctionName")
+
+package ca.solostudios.polybot.util.jda
+
+import club.minnced.discord.webhook.send.WebhookMessage
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.JDABuilder
+import net.dv8tion.jda.api.requests.GatewayIntent
+
+
+/**
+ * Creates a new [JDA] instance with the default settings by using [JDABuilder.createDefault]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param builder The function used to configure the builder.
+ * @return The new [JDA] instance.
+ * @see JDABuilder.createDefault
+ */
+inline fun DefaultJDA(
+        token: String? = null,
+        builder: InlineJDABuilder.() -> Unit
+                     ) = InlineJDABuilder(JDABuilder.createDefault(token)).also(builder).build()
+
+/**
+ * Creates a new [JDA] instance with the default settings by using [JDABuilder.createDefault]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The new [JDA] instance.
+ * @see JDABuilder.createDefault
+ */
+inline fun DefaultJDA(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+                     ) = InlineJDABuilder(JDABuilder.createDefault(token, intents.toList())).also(builder).build()
+
+/**
+ * Creates a new [JDABuilder] instance with the default settings by using [JDABuilder.createDefault]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param builder The function used to configure the builder.
+ * @return The [JDABuilder] instance. You must call [JDABuilder.build] on this to finish constructing the JDA.
+ * @see JDABuilder.createDefault
+ */
+inline fun DefaultJDABuilder(
+        token: String? = null,
+        builder: InlineJDABuilder.() -> Unit
+                            ) = InlineJDABuilder(JDABuilder.createDefault(token)).also(builder)
+
+/**
+ * Creates a new [JDABuilder] instance with the default settings by using [JDABuilder.createDefault]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The [JDABuilder] instance. You must call [JDABuilder.build] on this to finish constructing the JDA.
+ * @see JDABuilder.createDefault
+ */
+inline fun DefaultJDABuilder(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+                            ) = InlineJDABuilder(JDABuilder.createDefault(token, intents.toList())).also(builder)
+
+/**
+ * Creates a new [JDA] instance with the default settings by using [JDABuilder.createLight]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param builder The function used to configure the builder.
+ * @return The new [JDA] instance.
+ * @see JDABuilder.createLight
+ */
+inline fun LightJDA(
+        token: String? = null,
+        builder: InlineJDABuilder.() -> Unit
+                   ) = InlineJDABuilder(JDABuilder.createLight(token)).also(builder).build()
+
+/**
+ * Creates a new [JDA] instance with the default settings by using [JDABuilder.createLight]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The new [JDA] instance.
+ * @see JDABuilder.createLight
+ */
+inline fun LightJDA(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+                   ) = InlineJDABuilder(JDABuilder.createLight(token, intents.toList())).also(builder).build()
+
+/**
+ * Creates a new [JDABuilder] instance with the default settings by using [JDABuilder.createLight]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param builder The function used to configure the builder.
+ * @return The [JDABuilder] instance. You must call [JDABuilder.build] on this to finish constructing the JDA.
+ * @see JDABuilder.createLight
+ */
+inline fun LightJDABuilder(
+        token: String? = null,
+        builder: InlineJDABuilder.() -> Unit
+                          ) = InlineJDABuilder(JDABuilder.createLight(token)).also(builder)
+
+/**
+ * Creates a new [JDABuilder] instance with the default settings by using [JDABuilder.createLight]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The [JDABuilder] instance. You must call [JDABuilder.build] on this to finish constructing the JDA.
+ * @see JDABuilder.createLight
+ */
+inline fun LightJDABuilder(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+                          ) = InlineJDABuilder(JDABuilder.createLight(token, intents.toList())).also(builder)
+
+/**
+ * Creates a new [JDA] instance with the default settings by using [JDABuilder.create]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The new [JDA] instance.
+ * @see JDABuilder.create
+ */
+inline fun JDA(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+              ) = InlineJDABuilder(JDABuilder.create(token, intents.toList())).also(builder).build()
+
+/**
+ * Creates a new [JDABuilder] instance with the default settings by using [JDABuilder.create]
+ *
+ * @param token The token to log in with. If set to null, assign a value to [InlineJDABuilder.token].
+ * @param intents A list of intents to enable.
+ * @param builder The function used to configure the builder.
+ * @return The [JDABuilder] instance. You must call [JDABuilder.build] on this to finish constructing the JDA.
+ * @see JDABuilder.create
+ */
+inline fun JDABuilder(
+        token: String? = null,
+        vararg intents: GatewayIntent,
+        builder: InlineJDABuilder.() -> Unit
+                     ) = InlineJDABuilder(JDABuilder.create(token, intents.toList())).also(builder)
+
+
+inline fun WebhookMessage(builder: InlineWebhookMessage.() -> Unit = {}): WebhookMessage {
+    return club.minnced.discord.webhook.send.WebhookMessageBuilder().run {
+        InlineWebhookMessage(this).builder()
+        build()
+    }
+}
+
+inline fun WebhookMessageBuilder(builder: InlineWebhookMessage.() -> Unit = {}): InlineWebhookMessage {
+    return club.minnced.discord.webhook.send.WebhookMessageBuilder().run {
+        InlineWebhookMessage(this).apply(builder)
+    }
+}

--- a/src/main/kotlin/ca/solostudios/polybot/util/jda/jda.kt
+++ b/src/main/kotlin/ca/solostudios/polybot/util/jda/jda.kt
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2021 solonovamax <solonovamax@12oclockpoint.com>
  *
  * The file jda.kt is part of PolyhedralBot
- * Last modified on 12-10-2021 07:25 p.m.
+ * Last modified on 31-12-2021 01:29 p.m.
  *
  * MIT License
  *
@@ -28,7 +28,7 @@
 
 @file:Suppress("unused")
 
-package ca.solostudios.polybot.util
+package ca.solostudios.polybot.util.jda
 
 import ca.solostudios.polybot.PolyBot
 import ca.solostudios.polybot.entities.PolyAbstractChannel
@@ -54,6 +54,51 @@ import net.dv8tion.jda.api.entities.TextChannel
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.VoiceChannel
 import net.dv8tion.jda.api.managers.Presence
+import net.dv8tion.jda.api.utils.MemberCachePolicy
+
+/**
+ *
+ * Convenience Infix function for [MemberCachePolicy.or] to concatenate another policy.
+ * This allows you to drop the brackets for cache policies declarations.
+ *
+ * This way you can do
+ * ```kotlin
+ * memberCachePolicy = MemberCachePolicy.ONLINE or MemberCachePolicy.VOICE
+ * ```
+ * instead of
+ * ```kotlin
+ * memberCachePolicy = MemberCachePolicy.ONLINE.or(MemberCachePolicy.VOICE)
+ * ```
+ *
+ * @param policy The policy to concat
+ * @return New policy which combines both using a logical OR
+ * @see InlineJDABuilder.memberCachePolicy
+ */
+infix fun MemberCachePolicy.or(policy: MemberCachePolicy): MemberCachePolicy {
+    return policy.or(policy)
+}
+
+/**
+ *
+ * Convenience Infix function for [MemberCachePolicy.or] to require another policy.
+ * This allows you to drop the brackets for cache policies declarations.
+ *
+ * This way you can do
+ * ```kotlin
+ * memberCachePolicy = MemberCachePolicy.ONLINE and MemberCachePolicy.VOICE
+ * ```
+ * instead of
+ * ```kotlin
+ * memberCachePolicy = MemberCachePolicy.ONLINE.and(MemberCachePolicy.VOICE)
+ * ```
+ *
+ * @param policy The policy to require in addition to this one
+ * @return New policy which combines both using a logical AND
+ * @see InlineJDABuilder.memberCachePolicy
+ */
+infix fun MemberCachePolicy.and(policy: MemberCachePolicy): MemberCachePolicy {
+    return policy.and(policy)
+}
 
 var Presence.onlineStatus: OnlineStatus
     set(value) {


### PR DESCRIPTION
Migrates jda-ktx to the latest version.

This drops our [custom version](https://github.com/solonovamax/jda-ktx) of jda-ktx in favour for the [upstream version](https://github.com/MinnDevelopment/jda-ktx).

This was done because maintaining a custom version for a few very simple classes was too much effort.

Those classes have been added to the util.jda package.